### PR TITLE
Add lua-readline submodule; Make repl mode readline-ified

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,6 @@
 	path = submodules/rosie-lpeg
 	url = https://github.com/jamiejennings/rosie-lpeg.git
 	
+[submodule "submodules/lua-readline"]
+	path = submodules/lua-readline
+	url = https://github.com/bcnjr5/lua-readline.git

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ PLATFORMS = linux macosx windows
 LUA = lua
 LPEG = rosie-lpeg
 JSON = lua-cjson
+READLINE = lua-readline
 
 HOME = $(shell pwd)
 TMP = submodules
@@ -32,6 +33,7 @@ default: $(PLATFORM)
 LUA_DIR = $(TMP)/$(LUA)
 LPEG_DIR = $(TMP)/$(LPEG)
 JSON_DIR = $(TMP)/$(JSON)
+READLINE_DIR = $(TMP)/$(READLINE)
 
 ## ----------------------------------------------------------------------------- ##
 
@@ -42,6 +44,7 @@ clean:
 	-cd $(LUA_DIR) && make clean
 	-cd $(LPEG_DIR)/src && make clean
 	-cd $(JSON_DIR) && make clean
+	-cd $(READLINE_DIR) && rm readline.so && rm src/lua_readline.o
 
 none:
 	@echo "Your platform was not recognized.  Please do 'make PLATFORM', where PLATFORM is one of these: $(PLATFORMS)"
@@ -65,16 +68,17 @@ linux: PLATFORM=linux
 linux: CC=gcc
 linux: CJSON_MAKE_ARGS+=CJSON_CFLAGS+=-std=gnu99
 linux: CJSON_MAKE_ARGS+=CJSON_LDFLAGS=-shared
-linux: bin/lua lib/lpeg.so lib/cjson.so compile sniff
+linux: bin/lua lib/lpeg.so lib/cjson.so lib/readline.so compile sniff
 
 windows:
 	@echo Windows installation not yet supported.
 
-submodules: submodules/lua/Makefile submodules/lua-cjson/Makefile submodules/rosie-lpeg/src/Makefile
+submodules: submodules/lua/Makefile submodules/lua-cjson/Makefile submodules/rosie-lpeg/src/Makefile submodules/lua-readline/Makefile
 
 submodules/lua/Makefile:
 submodules/lua-cjson/Makefile:
 submodules/rosie-lpeg/src/Makefile:
+submodules/lua-readline/Makefile:
 	git submodule init
 	git submodule update
 
@@ -97,6 +101,11 @@ lib/cjson.so: submodules submodules/lua/include
 	cd $(JSON_DIR) && $(MAKE) CC=$(CC) $(CJSON_MAKE_ARGS)
 	mkdir -p lib
 	cp $(JSON_DIR)/cjson.so lib
+
+lib/readline.so: submodules submodules/lua/include
+	cd $(READLINE_DIR) && $(MAKE) CC=$(CC) CFLAGS="-fPIC -O2 -I../lua/include"
+	mkdir -p lib
+	cp $(READLINE_DIR)/readline.so lib
 
 bin/%.luac: src/core/%.lua bin/luac
 	bin/luac -o $@ $<

--- a/src/core/repl.lua
+++ b/src/core/repl.lua
@@ -9,6 +9,7 @@
 lapi = require "lapi"
 common = require "common"
 json = require "cjson"
+local readline = require "readline"
 
 local repl_patterns = [==[
       rpl_expression = expression
@@ -58,8 +59,9 @@ function repl(en)
    if (not ok) then
       error("Argument to repl is not a live engine: " .. tostring(en))
    end
-   io.write(repl_prompt)
-   local s = io.stdin:read("l")
+   --io.write(repl_prompt)
+   --local s = io.stdin:read("l")
+   local s = readline.readline(repl_prompt)
    if s==nil then io.write("\nExiting\n"); return nil; end -- EOF, e.g. ^D at terminal
    if s~="" then					   -- blank line input
       local ok, msg = lapi.configure_engine(repl_engine, {expression="input", encode=false})
@@ -195,6 +197,7 @@ function repl(en)
 	 end -- switch on type of input received
       end
    end
+   readline.add_history(s)
    repl(en)
 end
 


### PR DESCRIPTION
For #14 

This adds a new submodule, lua-readline (MIT license), which generates readline.so and placed in the lib folder. Based on current master branch (not my argparse branch, will rebase when needed).

This uses readline's input prompting to remember previous inputs and allows for recovery of previous inputs.

