### PR TITLE
Add RFC3986 expressions

### DIFF
--- a/rpl/rfc3986.rpl
+++ b/rpl/rfc3986.rpl
@@ -1,0 +1,136 @@
+
+alias ALPHA = letter
+alias DIGIT = digit
+alias HEXDIG =	DIGIT /
+				"A" / "a" /
+				"B" / "b" /
+				"C" / "c" /
+				"D" / "d" /
+				"E" / "e" /
+				"F" / "f"
+
+alias sub_delims = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
+alias gen_delims = ":" / "/" / "?" / "#" / "[" / "]" / "@"
+alias reserved = gen_delims / sub_delims
+
+alias unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
+
+alias pct_encoded = "%" HEXDIG HEXDIG
+
+alias pchar = unreserved / pct_encoded / sub_delims / ":" / "@"
+
+fragment = ({ pchar / "/" / "?" }*)
+
+query = ({ pchar / "/" / "?" }*)
+
+alias segment_nz_nc = ( unreserved / pct_encoded / sub_delims / "@" )+
+alias segment_nz = pchar+
+alias segment = pchar*
+
+path_empty = pchar{0,0}
+path_rootless = segment_nz { "/" segment }*
+path_noscheme = segment_nz_nc { "/" segment }*
+path_absolute = "/" { segment_nz { "/" segment }* }*
+path_abempty = { "/" segment }*
+
+path = path_empty / path_rootless / path_noscheme / path_absolute / path_abempty
+
+alias reg_name = { unreserved / pct_encoded / sub_delims }*
+
+alias dec_octet = {{"25" [0-5]} / {"2" [0-4] digit} / {"1" digit digit} / {[1-9] digit} / {digit}}
+
+alias IPv4address = dec_octet "." dec_octet "." dec_octet "." dec_octet
+
+alias h16 = HEXDIG{1,4}
+alias ls32 = { h16 ":" h16 } / IPv4address
+
+-- This is RFC3986's definition, but since rosie is always greedy matching it has to be exploded out to be more specific
+--alias IPv6address = {                               { h16 ":" }{6,6} ls32 } /
+--					{                          "::" { h16 ":" }{5,5} ls32 } /
+--					{ {                 h16 }? "::" { h16 ":" }{4,4} ls32 } /
+--					{ { { h16 ":" }{,1} h16 }? "::" { h16 ":" }{3,3} ls32 } /
+--					{ { { h16 ":" }{,2} h16 }? "::" { h16 ":" }{2,2} ls32 } /
+--					{ { { h16 ":" }{,3} h16 }? "::"   h16 ":"        ls32 } /
+--					{ { { h16 ":" }{,4} h16 }? "::"                  ls32 } /
+--					{ { { h16 ":" }{,5} h16 }? "::"                  h16  } /
+--					{ { { h16 ":" }{,6} h16 }? "::"                       }
+
+-- I'm fairly certain this can be optimized a little more
+alias IPv6address = {                                { h16 ":" }{6,6} ls32 } / -- exactly 8 groups
+					{                           "::" { h16 ":" }{5,5} ls32 } / -- leading 0 group, 7 trailing groups
+					{ {                  h16 }? "::" { h16 ":" }{4,4} ls32 } / -- one optional first group  or two   0 groups, 6 trailing groups
+					{ {                  h16 }? "::" { h16 ":" }{3,3} ls32 } / -- one optional first group  or three 0 groups, 5 trailing groups
+					{ {          h16 ":" h16 }? "::" { h16 ":" }{3,3} ls32 } / -- two optional first groups or three 0 groups, 5 trailing groups
+					{ {                  h16 }? "::" { h16 ":" }{2,2} ls32 } /
+					{ {          h16 ":" h16 }? "::" { h16 ":" }{2,2} ls32 } /
+					{ { { h16 ":" }{2,2} h16 }? "::" { h16 ":" }{2,2} ls32 } / -- {h16":"}{,2}
+					{ {                  h16 }? "::"   h16 ":"        ls32 } /
+					{ {          h16 ":" h16 }? "::"   h16 ":"        ls32 } /
+					{ { { h16 ":" }{2,2} h16 }? "::"   h16 ":"        ls32 } /
+					{ { { h16 ":" }{3,3} h16 }? "::"   h16 ":"        ls32 } / -- {h16":"}{,3}
+					{ {                  h16 }? "::"                  ls32 } /
+					{ {          h16 ":" h16 }? "::"                  ls32 } /
+					{ { { h16 ":" }{2,2} h16 }? "::"                  ls32 } /
+					{ { { h16 ":" }{3,3} h16 }? "::"                  ls32 } /
+					{ { { h16 ":" }{4,4} h16 }? "::"                  ls32 } / -- {h16":"}{,4}
+					{ {                  h16 }? "::"                  h16  } /
+					{ {          h16 ":" h16 }? "::"                  h16  } /
+					{ { { h16 ":" }{2,2} h16 }? "::"                  h16  } /
+					{ { { h16 ":" }{3,3} h16 }? "::"                  h16  } /
+					{ { { h16 ":" }{4,4} h16 }? "::"                  h16  } /
+					{ { { h16 ":" }{5,5} h16 }? "::"                  h16  } / -- {h16":"}{,5}
+					{ {                  h16 }? "::"                       } /
+					{ {          h16 ":" h16 }? "::"                       } /
+					{ { { h16 ":" }{2,2} h16 }? "::"                       } /
+					{ { { h16 ":" }{3,3} h16 }? "::"                       } /
+					{ { { h16 ":" }{4,4} h16 }? "::"                       } /
+					{ { { h16 ":" }{5,5} h16 }? "::"                       } /
+					{ { { h16 ":" }{6,6} h16 }? "::"                       }   -- {h16":"}{,6}
+
+alias IPvFuture = "v" HEXDIG+ "." { unreserved / sub_delims / ":" }+
+
+alias IP_literal = "[" { IPv6address / IPvFuture } "]"
+
+port = DIGIT*
+host = IP_literal / IPv4address / reg_name
+userinfo = { unreserved / pct_encoded / sub_delims / ":" }*
+authority = { userinfo "@" }? host { ":" port }?
+
+scheme = { ALPHA { ALPHA / DIGIT / "+" / "-" / "." }* }
+
+relative_part = { "//" authority path_abempty } /
+				path_absolute /
+				path_noscheme /
+				path_empty
+
+relative_ref = relative_part { "?" query }? { "#" fragment }?
+
+hier_part = { "//" authority path_abempty } /
+			path_absolute /
+			path_rootless /
+			path_empty
+
+absolute_URI = scheme ":" hier_part { "?" query }?
+
+URI = scheme ":" hier_part { "?" query }? { "#" fragment }?
+
+URI_reference = URI / relative_ref
+
+
+-- RFC3986 POSIX Regular Expression, Appendix B
+-- ^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?
+--  12            3  4          5       6  7        8 9
+-- scheme = 2
+-- authority = 4
+-- path = 5
+-- query = 7
+-- fragment = 9
+uri.alt.scheme = [^:/?#]+
+uri.alt.authority = [^/?#]*
+uri.alt.path = [^?#]*
+uri.alt.query = [^#]*
+uri.alt.fragment = .*
+-- This should match much faster than URI definition (less internal branching)
+uri.alt = { uri.alt.scheme ":" }? { "//" uri.alt.authority }? uri.alt.path { "?" uri.alt.query }? { "#" uri.alt.fragment }?
+-- This alt2 breaks down the authority section
+uri.alt2 = { uri.alt.scheme ":" }? { "//" authority }? uri.alt.path { "?" uri.alt.query }? { "#" uri.alt.fragment }?

--- a/rpl/rfc3986.rpl
+++ b/rpl/rfc3986.rpl
@@ -15,22 +15,22 @@ alias reserved = gen_delims / sub_delims
 
 alias unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
 
-alias pct_encoded = "%" HEXDIG HEXDIG
+alias pct_encoded = { "%" HEXDIG HEXDIG }
 
 alias pchar = unreserved / pct_encoded / sub_delims / ":" / "@"
 
-fragment = ({ pchar / "/" / "?" }*)
+fragment = { pchar / "/" / "?" }*
 
-query = ({ pchar / "/" / "?" }*)
+query = { pchar / "/" / "?" }*
 
-alias segment_nz_nc = ( unreserved / pct_encoded / sub_delims / "@" )+
+alias segment_nz_nc = { unreserved / pct_encoded / sub_delims / "@" }+
 alias segment_nz = pchar+
 alias segment = pchar*
 
 path_empty = pchar{0,0}
-path_rootless = segment_nz { "/" segment }*
-path_noscheme = segment_nz_nc { "/" segment }*
-path_absolute = "/" { segment_nz { "/" segment }* }*
+path_rootless = { segment_nz { "/" segment }* }
+path_noscheme = { segment_nz_nc { "/" segment }* }
+path_absolute = { "/" { segment_nz { "/" segment }* }* }
 path_abempty = { "/" segment }*
 
 path = path_empty / path_rootless / path_noscheme / path_absolute / path_abempty
@@ -39,7 +39,7 @@ alias reg_name = { unreserved / pct_encoded / sub_delims }*
 
 alias dec_octet = {{"25" [0-5]} / {"2" [0-4] digit} / {"1" digit digit} / {[1-9] digit} / {digit}}
 
-alias IPv4address = dec_octet "." dec_octet "." dec_octet "." dec_octet
+alias IPv4address = { dec_octet "." dec_octet "." dec_octet "." dec_octet }
 
 alias h16 = HEXDIG{1,4}
 alias ls32 = { h16 ":" h16 } / IPv4address
@@ -87,32 +87,32 @@ alias IPv6address = {                                { h16 ":" }{6,6} ls32 } / -
 					{ { { h16 ":" }{5,5} h16 }? "::"                       } /
 					{ { { h16 ":" }{6,6} h16 }? "::"                       }   -- {h16":"}{,6}
 
-alias IPvFuture = "v" HEXDIG+ "." { unreserved / sub_delims / ":" }+
+alias IPvFuture = { "v" HEXDIG+ "." { unreserved / sub_delims / ":" }+ }
 
-alias IP_literal = "[" { IPv6address / IPvFuture } "]"
+alias IP_literal = { "[" { IPv6address / IPvFuture } "]" }
 
 port = DIGIT*
 host = IP_literal / IPv4address / reg_name
 userinfo = { unreserved / pct_encoded / sub_delims / ":" }*
-authority = { userinfo "@" }? host { ":" port }?
+authority = { { userinfo "@" }? host { ":" port }? }
 
 scheme = { ALPHA { ALPHA / DIGIT / "+" / "-" / "." }* }
 
-relative_part = { "//" authority path_abempty } /
+relative_part = { { "//" authority path_abempty } /
 				path_absolute /
 				path_noscheme /
-				path_empty
+				path_empty }
 
-relative_ref = relative_part { "?" query }? { "#" fragment }?
+relative_ref = { relative_part { "?" query }? { "#" fragment }? }
 
-hier_part = { "//" authority path_abempty } /
+hier_part = { { "//" authority path_abempty } /
 			path_absolute /
 			path_rootless /
-			path_empty
+			path_empty }
 
-absolute_URI = scheme ":" hier_part { "?" query }?
+absolute_URI = { scheme ":" hier_part { "?" query }? }
 
-URI = scheme ":" hier_part { "?" query }? { "#" fragment }?
+URI = { scheme ":" hier_part { "?" query }? { "#" fragment }? }
 
 URI_reference = URI / relative_ref
 
@@ -131,6 +131,6 @@ uri.alt.path = [^?#]*
 uri.alt.query = [^#]*
 uri.alt.fragment = .*
 -- This should match much faster than URI definition (less internal branching)
-uri.alt = { uri.alt.scheme ":" }? { "//" uri.alt.authority }? uri.alt.path { "?" uri.alt.query }? { "#" uri.alt.fragment }?
+uri.alt = { { uri.alt.scheme ":" }? { "//" uri.alt.authority }? uri.alt.path { "?" uri.alt.query }? { "#" uri.alt.fragment }? }
 -- This alt2 breaks down the authority section
-uri.alt2 = { uri.alt.scheme ":" }? { "//" authority }? uri.alt.path { "?" uri.alt.query }? { "#" uri.alt.fragment }?
+uri.alt2 = { { uri.alt.scheme ":" }? { "//" authority }? uri.alt.path { "?" uri.alt.query }? { "#" uri.alt.fragment }? }


### PR DESCRIPTION
This is the expressions for URI matching based on [RFC3986](https://tools.ietf.org/html/rfc3986). A possible fix for #17 as well as enhancing IP address matching.

Examples of main matching:
```
Rosie> .match URI "ftp://bob:dole@www.google.com:80/a/b/c/page.cgi?query=something#offset"
{"URI": 
   {"subs": 
      [{"scheme": 
          {"text": "ftp", 
           "pos": 1.0}}, 
       {"hier_part": 
          {"subs": 
             [{"authority": 
                 {"subs": 
                    [{"userinfo": 
                        {"text": "bob:dole", 
                         "pos": 7.0}}, 
                     {"host": 
                        {"text": "www.google.com", 
                         "pos": 16.0}}, 
                     {"port": 
                        {"text": "80", 
                         "pos": 31.0}}], 
                  "pos": 7.0, 
                  "text": "bob:dole@www.google.com:80"}}, 
              {"path_abempty": 
                 {"text": "\/a\/b\/c\/page.cgi", 
                  "pos": 33.0}}], 
           "pos": 5.0, 
           "text": "\/\/bob:dole@www.google.com:80\/a\/b\/c\/page...."}}, 
       {"query": 
          {"text": "query=something", 
           "pos": 49.0}}, 
       {"fragment": 
          {"text": "offset", 
           "pos": 65.0}}], 
    "pos": 1.0, 
    "text": "ftp:\/\/bob:dole@www.google.com:80\/a\/b\/c\/p..."}}
```
There is one downside to this expression that I haven't been able to determine a better way to handle: the path name has 5 different variations and it's uncertain which you will have returned.

I added an alternative POSIX regex (seen in Appendix B of the RFC) as well.
```
Rosie> .match uri.alt "ftp://bob:dole@www.google.com:80/a/b/c/page.cgi?query=something#offset"
{"uri.alt": 
   {"subs": 
      [{"uri.alt.scheme": 
          {"text": "ftp", 
           "pos": 1.0}}, 
       {"uri.alt.authority": 
          {"text": "bob:dole@www.google.com:80", 
           "pos": 7.0}}, 
       {"uri.alt.path": 
          {"text": "\/a\/b\/c\/page.cgi", 
           "pos": 33.0}}, 
       {"uri.alt.query": 
          {"text": "query=something", 
           "pos": 49.0}}, 
       {"uri.alt.fragment": 
          {"text": "offset", 
           "pos": 65.0}}], 
    "pos": 1.0, 
    "text": "ftp:\/\/bob:dole@www.google.com:80\/a\/b\/c\/p..."}}
```

For breaking down the authority section, I added a second alternative:
```
Rosie> .match uri.alt2 "ftp://bob:dole@www.google.com:80/a/b/c/page.cgi?query=something#offset"
{"uri.alt2": 
   {"subs": 
      [{"uri.alt.scheme": 
          {"text": "ftp", 
           "pos": 1.0}}, 
       {"authority": 
          {"subs": 
             [{"userinfo": 
                 {"text": "bob:dole", 
                  "pos": 7.0}}, 
              {"host": 
                 {"text": "www.google.com", 
                  "pos": 16.0}}, 
              {"port": 
                 {"text": "80", 
                  "pos": 31.0}}], 
           "pos": 7.0, 
           "text": "bob:dole@www.google.com:80"}}, 
       {"uri.alt.path": 
          {"text": "\/a\/b\/c\/page.cgi", 
           "pos": 33.0}}, 
       {"uri.alt.query": 
          {"text": "query=something", 
           "pos": 49.0}}, 
       {"uri.alt.fragment": 
          {"text": "offset", 
           "pos": 65.0}}], 
    "pos": 1.0, 
    "text": "ftp:\/\/bob:dole@www.google.com:80\/a\/b\/c\/p..."}}
```

Matching _**valid**_ IP addresses are possible (which is an improvement over the current _ip\_address_ expression):
```
Rosie> .match IPv4address "127.0.0.1"
{"*": 
   {"text": "127.0.0.1", 
    "pos": 1.0}}
```
Errors when given an invalid IP:
```
Rosie> .match IPv4address "123.456.789.0"
     SEQUENCE: (dec_octet ~ "." ~ dec_octet ~ "." ~ dec_octet ~ "." ~ dec_octet)
     FAILED to match against input "123.456.789.0"
-----snip-----
 11...................................NAMED CHARSET: [:digit:]
                                      Matched "5" (against input "56.789.0")
                 REFERENCE: ~
                 FAILED to match against input "6.789.0"
                 This identifier is a built-in RPL pattern

Repl: No match  (turn debug off to hide the match evaluation trace)
```
Current _ip\_address_ expression:
```
Rosie> .match ip_address "123.456.789.0"
{"*": 
   {"text": "123.456.789.0", 
    "pos": 1.0}}
```

IPv6 addresses are also matchable:
```
Rosie> .match IPv6address "2001:db8::ff00:32:8439"
{"*": 
   {"text": "2001:db8::ff00:32:8439", 
    "pos": 1.0}}
```
It will still match this (with warning) unless adding a terminating match:
```
Rosie> .match IPv6address "::8:7:6:5:4:3:2:1"
{"*": 
   {"text": "::8:7:6:5:4:3:2", 
    "pos": 1.0}}
Warning: 2 unmatched characters at end of input
```
Terminating match:
```
Rosie> .match IPv6address !. "::8:7:6:5:4:3:2:1"
     SEQUENCE: (IPv6address ~ !.)
     FAILED to match against input "::8:7:6:5:4:3:2:1"
----snip-----
  7.....PREDICATE: !.
        FAILED to match against input ":1"
        Explanation (EXPRESSION): !.
           REFERENCE: .
           Matched ":" (against input ":1")
           This identifier is a built-in RPL pattern

Repl: No match  (turn debug off to hide the match evaluation trace)
```