### PR TITLE
Vim syntax highlighting

### DIFF
--- a/extra/vim/ftdetect/rosie.vim
+++ b/extra/vim/ftdetect/rosie.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *.rosie set filetype=rosie

--- a/extra/vim/syntax/rosie.vim
+++ b/extra/vim/syntax/rosie.vim
@@ -1,0 +1,86 @@
+" Vim syntax file
+" Language:     Rosie Pattern Language
+" Maintainer:   Kevin Zander <veratil@gmail.com>
+" Contributors:
+" Last Change:  07-Dec-2016
+" Bugs:
+
+if version < 600
+	syntax clear
+elseif exists("b:current_syntax")
+	finish
+endif
+
+" for future expansion, not used now
+function! s:GetRPLVersion()
+	if exists("b:rosie_version")
+		return b:rosie_version
+	elseif exists("g:rosie_version")
+		return g:rosie_version
+	else
+		return 999
+	endif
+endfunction
+
+" alias name = expression
+syn	keyword	rosieKeyword	alias
+
+" grammar
+"  ...
+" end
+syn	keyword	rosieGrammar	grammar end
+
+" { ... }
+syn	match	rosieRawGroup	"{"
+syn	match	rosieRawGroup	"}"
+
+" ( ... )
+syn	match	rosieCookedGroup	"("
+syn	match	rosieCookedGroup	")"
+
+syn	match	rosieAssignment	"="
+
+syn	match	rosieChoice	"/"
+
+syn	match	rosieRepetition	"*"
+syn	match	rosieRepetition	"?"
+syn	match	rosieRepetition	"+"
+
+" Repetition specific
+syn	match	rosieRepetitionRange	/{\s*\d*\s*,\s*\d*\s*}/
+
+syn	match	rosiePredicate	"!"
+syn	match	rosiePredicate	"@"
+
+syn	match	rosieCharlist		/\v\[\^?[^[\]]+]/
+syn	match	rosieRange			/\v\[\^?([^\\[^\]]|\\.)-([^\\[^\]]|\\.)]/
+syn	match	rosieNamedCharset	/\v\[:\^?[^:]+:]/
+
+" This looks for two open square brackets, skipping whitespace
+" The region contains any of the above sets (highlighted separately)
+" The end will match the final ] as the inside matches will consume their ]
+syn	region	rosieCharset	start=/\v\[\[/	end=/\v]/	skipwhite contains=rosieCharlist,rosieRange,rosieNamedCharset oneline
+
+syn	region	rosieString		start=+"+	skip=+\\\\\|\\"+	end=+"+	oneline
+
+syn	region	rosieComment	start="--"	end="$" oneline
+
+highlight	link	rosieKeyword			Keyword
+highlight	link	rosieGrammar			Typedef
+highlight	link	rosieString				String
+highlight	link	rosieComment			Comment
+highlight	link	rosieAssignment			Operator
+highlight	link	rosieChoice				Operator
+highlight	link	rosieRepetition			Operator
+highlight	link	rosieRepetitionRange	Define
+highlight	link	rosieRawGroup			Structure
+highlight	link	rosieCookedGroup		StorageClass
+highlight	link	rosiePredicate			Delimiter
+highlight	link	rosieCharset			Macro
+highlight	link	rosieCharlist			Label
+highlight	link	rosieRange				Delimiter
+highlight	link	rosieNamedCharset		Include
+
+let b:current_syntax = "rosie"
+
+" vim:ts=4

--- a/extra/vim/syntax/rosie.vim
+++ b/extra/vim/syntax/rosie.vim
@@ -65,21 +65,27 @@ syn	region	rosieString		start=+"+	skip=+\\\\\|\\"+	end=+"+	oneline
 
 syn	region	rosieComment	start="--"	end="$" oneline
 
-highlight	link	rosieKeyword			Keyword
-highlight	link	rosieGrammar			Typedef
-highlight	link	rosieString				String
-highlight	link	rosieComment			Comment
-highlight	link	rosieAssignment			Operator
-highlight	link	rosieChoice				Operator
-highlight	link	rosieRepetition			Operator
-highlight	link	rosieRepetitionRange	Define
-highlight	link	rosieRawGroup			Structure
-highlight	link	rosieCookedGroup		StorageClass
-highlight	link	rosiePredicate			Delimiter
-highlight	link	rosieCharset			Macro
-highlight	link	rosieCharlist			Label
-highlight	link	rosieRange				Delimiter
-highlight	link	rosieNamedCharset		Include
+syn	keyword	rosieTestKeyword	accepts rejects	contained
+syn	region	rosieTest		start="-- test"	end="$"	oneline	contains=rosieString,rosieTestKeyword
+
+highlight link rosieKeyword 	Keyword
+highlight link rosieGrammar		Typedef
+highlight link rosieString		String
+highlight link rosieComment		Comment
+highlight link rosieAssignment	Operator
+highlight link rosieChoice		Operator
+highlight link rosieRepetition	Operator
+highlight link rosieRepetitionRange	Define
+highlight link rosieRawGroup	Structure
+highlight link rosieCookedGroup	StorageClass
+highlight link rosiePredicate	Delimiter
+highlight link rosieCharset		Macro
+highlight link rosieCharlist	Label
+highlight link rosieRange		Delimiter
+highlight link rosieNamedCharset	Include
+
+highlight link rosieTest		Special
+highlight link rosieTestKeyword	Debug
 
 let b:current_syntax = "rosie"
 

--- a/rpl/basic.rpl
+++ b/rpl/basic.rpl
@@ -1,4 +1,5 @@
 ---- -*- Mode: rpl; -*-                                                                             
+---- vim:syn=rosie
 ----
 ----  basic.rpl    A set of basic patterns that can be used to look for interesting things when the
 ----               input structure is unknown.  

--- a/rpl/common.rpl
+++ b/rpl/common.rpl
@@ -1,4 +1,5 @@
 ---- -*- Mode: rpl; -*-                                                                             
+---- vim:syn=rosie
 ----
 ---- common.rpl   Common patterns in Rosie Pattern Language
 ----

--- a/rpl/csv.rpl
+++ b/rpl/csv.rpl
@@ -1,4 +1,5 @@
 ---- -*- Mode: rpl; -*-                                                                             
+---- vim:syn=rosie
 ----
 ---- csv.rpl     RPL patterns for CSV files
 ----

--- a/rpl/csv1.rpl
+++ b/rpl/csv1.rpl
@@ -1,4 +1,5 @@
 ---- -*- Mode: rpl; -*-                                                                             
+---- vim:syn=rosie
 ----
 ---- csv1.rpl     Developing production-quality csv parsing (See blog on IBM developerWorks Open)
 ----

--- a/rpl/datetime.rpl
+++ b/rpl/datetime.rpl
@@ -1,4 +1,5 @@
 ---- -*- Mode: rpl; -*-                                                                             
+---- vim:syn=rosie
 ----
 ---- datetime.rpl    Common date/time patterns in Rosie Pattern Language
 ----

--- a/rpl/grep.rpl
+++ b/rpl/grep.rpl
@@ -1,4 +1,5 @@
 ---- -*- Mode: rpl; -*-                                                                             
+---- vim:syn=rosie
 ----
 ---- grep.rpl   grep-like patterns in Rosie Pattern Language
 ----

--- a/rpl/json.rpl
+++ b/rpl/json.rpl
@@ -1,4 +1,5 @@
 ---- -*- Mode: rpl; -*-                                                                             
+---- vim:syn=rosie
 ----
 ---- json.rpl    some rpl patterns for processing json input
 ----

--- a/rpl/language-comments.rpl
+++ b/rpl/language-comments.rpl
@@ -1,4 +1,5 @@
 ---- -*- Mode: rpl; -*-                                                                             
+---- vim:syn=rosie
 ----
 ---- language-comments.rpl   Extract comments (or just code) from source files
 ----

--- a/rpl/network.rpl
+++ b/rpl/network.rpl
@@ -1,4 +1,5 @@
 ---- -*- Mode: rpl; -*-                                                                             
+---- vim:syn=rosie
 ----
 ---- network.rpl     Rosie Pattern Language patterns for hostnames, ip addresses, and such
 ----

--- a/rpl/rosie.rpl
+++ b/rpl/rosie.rpl
@@ -1,4 +1,5 @@
 ---- -*- Mode: rpl; -*-                                                                             
+---- vim:syn=rosie
 ----
 ---- rosie.rpl    Some patterns specific to Rosie Pattern Language
 ----

--- a/rpl/spark.rpl
+++ b/rpl/spark.rpl
@@ -1,4 +1,5 @@
 ---- -*- Mode: rpl; -*-                                                                             
+---- vim:syn=rosie
 ----
 ---- spark.rpl       patterns for Apache Spark logs
 ----
@@ -49,4 +50,3 @@ spark.patterns = spark.typical /
 		 spark.command /
 		 spark.using_message /
 		 spark.ignore
-      

--- a/src/rpl-core.rpl
+++ b/src/rpl-core.rpl
@@ -1,4 +1,5 @@
 ---- -*- Mode: rpl; -*-                                                                             
+---- vim:syn=rosie
 ----
 ---- rpl-core.rpl       Rosie Pattern Language definition for Rosie Pattern Language
 ----

--- a/test/ok.rpl
+++ b/test/ok.rpl
@@ -1,4 +1,5 @@
 -- -*- Mode: rpl; -*- 
+-- vim:syn=rosie
 --
 -- ok.rpl   Rosie Pattern Language tests that compile ok
 --

--- a/test/synerr.rpl
+++ b/test/synerr.rpl
@@ -1,4 +1,5 @@
 -- -*- Mode: rpl; -*- 
+-- vim:syn=rosie
 --
 -- synerr.rpl   Rosie Pattern Language tests with syntax errors
 --

--- a/test/test-manifest.rpl
+++ b/test/test-manifest.rpl
@@ -1,4 +1,5 @@
 -- -*- Mode: rpl; -*- 
+-- vim:syn=rosie
 --
 -- test-manifest.rpl   Rosie Pattern Language tests that compile ok
 --

--- a/test/undef.rpl
+++ b/test/undef.rpl
@@ -1,4 +1,5 @@
 -- -*- Mode: rpl; -*- 
+-- vim:syn=rosie
 --
 -- undef.rpl   Rosie Pattern Language tests that fail
 --


### PR DESCRIPTION
Currently the vim filetype detection looks for a `*.rosie` file instead of `*.rpl` in anticipation for a filetype change. Easily changed if we decide something else.

Also added a vim modeline to set the syntax for all RPL files to "rosie".