### PR TITLE
Lightweight Test Framework

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,6 @@
 	path = submodules/rosie-lpeg
 	url = https://github.com/jamiejennings/rosie-lpeg.git
 	
+[submodule "submodules/argparse"]
+	path = submodules/argparse
+	url = https://github.com/mpeterv/argparse.git

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ endif
 
 PLATFORMS = linux macosx windows
 
+ARGPARSE = argparse
 LUA = lua
 LPEG = rosie-lpeg
 JSON = lua-cjson
@@ -29,6 +30,7 @@ EXECROSIE = "$(HOME)/$(ROSIEBIN)"
 
 default: $(PLATFORM)
 
+ARGP_DIR = $(TMP)/$(ARGPARSE)
 LUA_DIR = $(TMP)/$(LUA)
 LPEG_DIR = $(TMP)/$(LPEG)
 JSON_DIR = $(TMP)/$(JSON)
@@ -70,8 +72,9 @@ linux: bin/lua lib/lpeg.so lib/cjson.so compile sniff
 windows:
 	@echo Windows installation not yet supported.
 
-submodules: submodules/lua/Makefile submodules/lua-cjson/Makefile submodules/rosie-lpeg/src/Makefile
+submodules: submodules/argparse submodules/lua/Makefile submodules/lua-cjson/Makefile submodules/rosie-lpeg/src/Makefile
 
+submodules/argparse:
 submodules/lua/Makefile:
 submodules/lua-cjson/Makefile:
 submodules/rosie-lpeg/src/Makefile:
@@ -98,10 +101,13 @@ lib/cjson.so: submodules submodules/lua/include
 	mkdir -p lib
 	cp $(JSON_DIR)/cjson.so lib
 
+bin/argparse.luac: submodules/argparse/src/argparse.lua
+	bin/luac -o $@ $<
+
 bin/%.luac: src/core/%.lua bin/luac
 	bin/luac -o $@ $<
 
-luaobjects := $(patsubst src/core/%.lua,bin/%.luac,$(wildcard src/core/*.lua))
+luaobjects := $(patsubst src/core/%.lua,bin/%.luac,$(wildcard src/core/*.lua)) bin/argparse.luac
 
 compile: $(luaobjects)
 

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ install:
 	@-ln -sf "$(EXECROSIE)" "$(DESTDIR)/rosie" && chmod 755 "$(DESTDIR)/rosie"
 
 sniff: $(EXECROSIE)
-	@RESULT="$(shell $(EXECROSIE) 2>&1 >/dev/null)"; \
+	@RESULT="$(shell $(EXECROSIE) --version 2>&1 >/dev/null)"; \
 	EXPECTED="This is Rosie v$(shell head -1 $(HOME)/VERSION)"; \
 	if [ -n "$$RESULT" -a "$$RESULT" = "$$EXPECTED" ]; then \
 	    echo "";\

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -44,46 +44,49 @@ Rosie supports output in a few formats, which are controlled by the value of the
 ### Help is available
 
 ``` 
-bash-3.2$ ./bin/rosie -help
-This is Rosie v0.99a
-The Rosie install directory is: /Users/jjennings/Work/Dev/rosie-pattern-language
-Rosie help:
-Rosie usage: ./bin/rosie <options> <pattern> <filename>*
-Valid <options> are: -help -patterns -verbose -all -repl -grep -eval -wholefile -manifest -f -e -encode
+$ rosie --help
+Usage: rosie [--version] [-v] [-m <manifest>] [-f <load>] [-r <rpl>]
+       [-h] <command> ...
 
--help              prints this message
--patterns          print list of available patterns
--verbose           output warnings and other informational messages
--all               write matches to stdout and non-matching lines to stderr
--repl              start Rosie in the interactive mode (read-eval-print loop)
--grep              emulate grep (weakly), but with RPL, by searching for all
-                   occurrences of <pattern> in the input
--eval              output a detailed "trace" evaluation of how the pattern
-                   processed the input; this feature generates LOTS of output,
-                   so best to use it on ONE LINE OF INPUT
--wholefile         read the whole input file into memory as a single string,
-                   instead of line by line
--manifest <arg>    load the manifest file <arg> instead of MANIFEST from $sys
-                   (the Rosie install directory); use a single dash '-' to
-                   load no manifest file
--f <arg>           load the RPL file <arg>, after manifest (if any) is loaded;
-                   use a single dash '-' to read from the stdin
--e <arg>           compile the RPL statements in <arg>, after manifest and
-                   RPL file (if any) are loaded
--encode <arg>      encode output in <arg> format: color (default), nocolor,
-                   fulltext, or json
+Rosie Pattern Language v0.99i
 
-<pattern>            RPL expression, which may be the name of a defined pattern,
-                     against which each line will be matched
-<filename>+          one or more file names to process, the last of which may be
-                     a dash "-" to read from standard input
+Options:
+   --version             Print rosie version
+   -v, --verbose         Output additional messages
+   -m <manifest>, --manifest <manifest>
+                         Load a manifest file (default: $sys/MANIFEST)
+   -f <load>, --load <load>
+                         Load an RPL file
+   -r <rpl>, --rpl <rpl> Inline RPL statements
+   -h, --help            Show this help message and exit.
 
-Notes: 
-(1) lines from the input file for which the pattern does NOT match are written
-    to stderr so they can be redirected, e.g. to /dev/null
-(2) the -eval option currently does not work with the -grep option
+Commands:
+   info                  Print rosie installation information
+   patterns              List installed patterns
+   repl                  Run rosie in interactive mode
+   match                 Run RPL match
 
-bash-3.2$
+Additional information.
 ```
 
+For help on a command, pass the `-h` or `--help` option after a command.
+```
+$ bin/rosie match --help
+Usage: rosie match ([-e] | [-g]) [-s] [-a] [-o <encode>] [-h]
+       <pattern> [[<filename>] ...]
 
+Run RPL match
+
+Arguments:
+   pattern               RPL pattern
+   filename              Input filename (default: -)
+
+Options:
+   -s, --wholefile       Read input file as single string
+   -a, --all             Output non-matching lines to stderr
+   -e, --eval            Output detailed trace evaluation of pattern process.
+   -g, --grep            Weakly emulate grep using RPL syntax
+   -o <encode>, --encode <encode>
+                         Output format (default: color)
+   -h, --help            Show this help message and exit.
+```

--- a/rpl/common.rpl
+++ b/rpl/common.rpl
@@ -15,17 +15,29 @@ alias letter = [:alpha:]
 -- [:graph:] won't match unicode, but these will:
 alias common.graph = {![:space:] .}
 alias common.id_char = [_-] / {![:space:] ![:punct:] .}
+-- test common.id_char accepts "_", "-", "i", "3"
+-- test common.id_char rejects "#", "%", "`"
 
 alias hex_only = { [a-f] / [A-F] }
 alias hex_digits = { digit / [a-f] / [A-F] }
 --alias common.hex = { digit hex_digits+ } / { hex_only+ digit hex_digits* }
 common.int = { [+-]? digit+ !hex_only}	     -- at least one digit, and not a hex number
+-- test common.int accepts "34", "+34", "-34"
+-- test common.int rejects "BEEF", "0x20"
 common.float = { [+-]? digit+ "." digit+ }  -- float with digits on either side of radix
+-- test common.float accepts "1.23", "+1.23", "-1.23"
+-- test common.float rejects "12", "bob", "1."
 common.hex = hex_digits+ 		     --  use with care! will match words and decimal numbers
+-- test common.hex accepts "BEEF", "f4c3b00c"
+-- test common.hex rejects "0xBEEF", "Facebook"
 common.denoted_hex = { "0x" common.hex }
+-- test common.denoted_hex accepts "0xBEEF", "0x20"
+-- test common.denoted_hex rejects "BEEF", "0x2o"
 common.number =  (common.denoted_hex /  common.float / common.int / common.hex)
 
 common.word = letter+
+-- test common.word accepts "foo"
+-- test common.word rejects "12356", "  ", "#!", "ac475"
 
 -- This definition is essentially what grok uses, which isn't great:
 -- common.unix_path = { "/" ([:alnum:]/[_%!$@:.,~-])+ / ".." / "." }+

--- a/src/core/common.lua
+++ b/src/core/common.lua
@@ -136,7 +136,7 @@ function common.escape_string(s)
    return (string.format("%q", s)):sub(2,-2)
 end
 
-function common.print_env(env, skip_header, total)
+function common.print_env(env, filter, skip_header, total)
    -- print a sorted list of patterns contained in the flattened table 'env'
    local pattern_list = {}
 
@@ -148,6 +148,8 @@ function common.print_env(env, skip_header, total)
    table.sort(pattern_list)
    local patterns_loaded = #pattern_list
    total = (total or 0) + patterns_loaded
+   local filter = string.lower(filter) or nil
+   local filter_total = 0
 
    local fmt = "%-30s %-15s %-8s"
 
@@ -157,15 +159,29 @@ function common.print_env(env, skip_header, total)
       print("------------------------------ --------------- --------")
    end
    local kind, color;
-   for _,v in ipairs(pattern_list) do 
-      print(string.format(fmt, v, env[v].type, env[v].color))
+   if filter == nil then
+      for _,v in ipairs(pattern_list) do
+         print(string.format(fmt, v, env[v].type, env[v].color))
+      end
+   else
+      for _,v in ipairs(pattern_list) do
+         local s,e = string.find(string.lower(tostring(v)), filter)
+         if s ~= nil then
+            print(string.format(fmt, v, env[v].type, env[v].color))
+            filter_total = filter_total + 1
+         end
+      end
    end
    if patterns_loaded==0 then
       print("<empty>");
    end
    if not skip_header then
       print()
-      print(total .. " patterns")
+      if filter == nil then
+         print(total .. " patterns")
+      else
+         print(filter_total .. " / " .. total .. " patterns")
+      end
    end
 end
 

--- a/src/core/common.lua
+++ b/src/core/common.lua
@@ -148,7 +148,7 @@ function common.print_env(env, filter, skip_header, total)
    table.sort(pattern_list)
    local patterns_loaded = #pattern_list
    total = (total or 0) + patterns_loaded
-   local filter = string.lower(filter) or nil
+   local filter = filter and string.lower(filter) or nil
    local filter_total = 0
 
    local fmt = "%-30s %-15s %-8s"

--- a/src/core/repl.lua
+++ b/src/core/repl.lua
@@ -22,7 +22,7 @@ local repl_patterns = [==[
       eval = ".eval" args
       on_off = "on" / "off"
       debug = ".debug" on_off?
-      patterns = ".patterns"
+      patterns = ".patterns" identifier?
       star = "*"
       clear = ".clear" (identifier / star)?
       help = ".help"
@@ -114,7 +114,11 @@ function repl(en)
 	       io.write("Debug is ", (debug and "on") or "off", "\n")
 	    elseif cname=="patterns" then
 	       local env = lapi.get_environment(en)
-	       common.print_env(env)
+	       local filter = nil
+	       if csubs then
+	          _,_,filter,_ = common.decode_match(csubs[1])
+	       end
+	       common.print_env(env, filter)
 	    elseif cname=="clear" then
 	       if csubs and csubs[1] then
 		  local name, pos, id, subs = common.decode_match(csubs[1])
@@ -210,7 +214,7 @@ local help_text = [[
    .match exp quoted_string      match RPL exp against (quoted) input data
    .eval exp quoted_string       show full evaluation (trace)
    .debug {on|off}               show debug state; with an argument, set it
-   .patterns                     list patterns in the environment
+   .patterns [filter]            list patterns in the environment
    .clear <id>                   clear the pattern definition of <id>, * for all
    .help                         print this message
 

--- a/src/run.lua
+++ b/src/run.lua
@@ -187,6 +187,89 @@ function run(args)
 
 	setup_engine(args);
 
+	if args.command == "test" then
+		local function startswith(str,sub)
+			return string.sub(str,1,string.len(sub))==sub
+		end
+		-- from http://www.inf.puc-rio.br/~roberto/lpeg/lpeg.html
+		local function split(s, sep)
+			sep = lpeg.P(sep)
+			local elem = lpeg.C((1 - sep)^0)
+			local p = lpeg.Ct(elem * (sep * elem)^0)
+			return lpeg.match(p, s)
+		end
+		local function find_test_lines(str)
+			local num = 0
+			local lines = {}
+			for _,line in pairs(split(str, "\n")) do
+				if startswith(line,'-- test') then
+					table.insert(lines, line)
+					num = num + 1
+				end
+			end
+			return num, lines
+		end
+		local f = io.open(args.filename, 'r')
+		local num_patterns, test_lines = find_test_lines(f:read('*a'))
+		f:close()
+		if num_patterns > 0 then
+			local function set_config_exp(exp, encode)
+				local en = encode or false
+				local success, msg = lapi.configure_engine(CL_ENGINE, {expression=exp, encode=en})
+				if not success then
+					print("Error configuring engine expression")
+					print(msg)
+					os.exit(-1)
+				end
+			end
+			local function test_accepts_exp(q)
+				local res, pos = lapi.match(CL_ENGINE, q)
+				if pos ~= 0 then return false end
+				return true
+			end
+			local function test_rejects_exp(q)
+				local res, pos = lapi.match(CL_ENGINE, q)
+				if pos == 0 then return false end
+				return true
+			end
+			local test_funcs = {test_rejects_exp=test_rejects_exp,test_accepts_exp=test_accepts_exp}
+			local test_patterns = [==[
+				testKeyword = "accepts" / "rejects"
+				test_line = "-- test" identifier testKeyword quoted_string (ignore "," ignore quoted_string)*
+			]==]
+			lapi.load_file(CL_ENGINE, "$sys/src/rpl-core.rpl")
+			lapi.load_string(CL_ENGINE, test_patterns)
+			local failures = 0
+			for _,p in pairs(test_lines) do
+				set_config_exp("test_line")
+				local m, left = lapi.match(CL_ENGINE, p)
+				-- FIXME: need to test for failure to match
+				local name = m.test_line.subs[1].identifier.text
+				set_config_exp(name)
+				local testtype = m.test_line.subs[2].testKeyword.text
+				local testfunc = test_funcs["test_" .. testtype .. "_exp"]
+				local literals = 3 -- literals will start at subs offset 3
+				-- if we get here we have at least one per test_line expression rule
+				while literals <= #m.test_line.subs do
+					local teststr = m.test_line.subs[literals].literal.text
+					if not testfunc(teststr) then
+						print("FAIL: " .. name .. " did not " .. testtype:sub(1,-2) .. " " .. teststr)
+						failures = failures + 1
+					end
+					literals = literals + 1
+				end
+			end
+			if failures == 0 then
+				print("All tests passed")
+			else
+				os.exit(-1)
+			end
+		else
+			print("No tests found")
+		end
+		os.exit()
+	end
+
 	if args.command == "patterns" then
 		if not args.verbose then greeting(); end
 		local env = lapi.get_environment(CL_ENGINE)
@@ -291,6 +374,9 @@ match:argument("pattern", "RPL pattern")
 match:argument("filename", "Input filename")
 	:args("*")
 	:default("-") -- in case no filenames are passed, default to stdin
+-- test command
+local test = parser:command("test")
+test:argument("filename", "RPL filename")
 -- in order to catch dev mode for "make test"
 if (not arg[1]) then
 	print(parser:get_help())

--- a/src/run.lua
+++ b/src/run.lua
@@ -190,7 +190,7 @@ function run(args)
 	if args.command == "patterns" then
 		if not args.verbose then greeting(); end
 		local env = lapi.get_environment(CL_ENGINE)
-		common.print_env(env)
+		common.print_env(env, args.filter)
 		os.exit()
 	end
 
@@ -247,6 +247,10 @@ local info = parser:command("info")
 -- patterns command
 local patterns = parser:command("patterns")
 	:description("List installed patterns")
+patterns:argument("filter")
+	:description("Filter pattern names that have substring 'filter'")
+	:args("?")
+	:default("")
 -- repl command
 local repl = parser:command("repl")
 	:description("Run rosie in interactive mode")

--- a/src/run.lua
+++ b/src/run.lua
@@ -250,7 +250,6 @@ local patterns = parser:command("patterns")
 patterns:argument("filter")
 	:description("Filter pattern names that have substring 'filter'")
 	:args("?")
-	:default("")
 -- repl command
 local repl = parser:command("repl")
 	:description("Run rosie in interactive mode")

--- a/src/run.lua
+++ b/src/run.lua
@@ -1,4 +1,4 @@
----- -*- Mode: Lua; -*-                                                                           
+---- -*- Mode: Lua; -*-
 ----
 ---- run.lua
 ----
@@ -20,8 +20,8 @@
 -- not need to process that switch.
 
 if not ROSIE_HOME then
-   io.stderr:write("Installation error: Lua variable ROSIE_HOME is not defined\n")
-   os.exit(-2)
+	io.stderr:write("Installation error: Lua variable ROSIE_HOME is not defined\n")
+	os.exit(-2)
 end
 -- if not SCRIPTNAME then
 --    io.stderr:write("Installation error: Lua variable SCRIPTNAME is not defined\n")
@@ -32,17 +32,18 @@ end
 
 local thunk, msg = loadfile(ROSIE_HOME .. "/bin/bootstrap.luac")
 if not thunk then
-   io.stderr:write("Rosie CLI warning: compiled Rosie files not available, loading from source\n")
-   dofile(ROSIE_HOME.."/src/core/bootstrap.lua")
+	io.stderr:write("Rosie CLI warning: compiled Rosie files not available, loading from source\n")
+	dofile(ROSIE_HOME.."/src/core/bootstrap.lua")
 else
-   local ok, msg = pcall(thunk)
-   if not ok then
-      io.stderr:write("Rosie CLI warning: error loading compiled Rosie files, will load from source \n")
-      io.stderr:write(msg, "\n")
-      dofile(ROSIE_HOME.."/src/core/bootstrap.lua")
-   end
+	local ok, msg = pcall(thunk)
+	if not ok then
+		io.stderr:write("Rosie CLI warning: error loading compiled Rosie files, will load from source \n")
+		io.stderr:write(msg, "\n")
+		dofile(ROSIE_HOME.."/src/core/bootstrap.lua")
+	end
 end
 
+local argparse = require "argparse"
 local common = require "common"
 local lapi = require "lapi"
 local json = require "cjson"
@@ -53,320 +54,235 @@ CL_ENGINE, msg = lapi.new_engine({name="command line engine"})
 if (not CL_ENGINE) then error("Internal error: could not obtain new engine: " .. msg); end
 
 local function greeting()
-   io.stderr:write("This is Rosie v" .. ROSIE_VERSION .. "\n")
-end
-
-local options_without_args = {"-help", "-patterns", "-verbose", "-all",
-			      "-repl", "-grep", "-eval", "-wholefile", "-info"}
-local options_with_args = {"-manifest", "-f", "-e", "-encode"}
-
-local valid_options = append(options_without_args, options_with_args)
-
-local help_messages =
-   { ["-help"] = {"prints this message"},
-     ["-info"] = {"prints information about the local rosie installation"},
-     ["-verbose"] = {"output warnings and other informational messages"},
-     ["-repl"] = {"start Rosie in the interactive mode (read-eval-print loop)"},
-     ["-patterns"] = {"print list of available patterns"},
-     ["-encode"] = {"encode output in <arg> format: color (default), nocolor,",
-		    "fulltext, or json"},
-     ["-wholefile"] = {"read the whole input file into memory as a single string,",
-		       "instead of line by line"},
-     ["-all"] = {"write matches to stdout and non-matching lines to stderr"},
-     ["-eval"] = {"output a detailed \"trace\" evaluation of how the pattern",
-		  "processed the input; this feature generates LOTS of output,",
-		  "so best to use it on ONE LINE OF INPUT"},
-     ["-grep"] = {"emulate grep (weakly), but with RPL, by searching for all",
-		  "occurrences of <pattern> in the input"},
-     ["-manifest"] = {"load the manifest file <arg> instead of MANIFEST from $sys",
-		      "(the Rosie install directory); use a single dash '-' to",
-		      "load no manifest file"},
-     ["-f"] = {"load the RPL file <arg>, after manifest (if any) is loaded"},
-     ["-e"] = {"compile the RPL statements in <arg>, after manifest and",
-	       "RPL file (if any) are loaded"},
-  }
-
-local function option_takes_arg(optname)
-   return member(optname, options_with_args)
-end
-
-local function valid_option_is(opt)
-   for i,v in ipairs(valid_options) do
-      if v==opt then return i; end
-   end
-   return false
-end
-
-local usage_message = "Usage: "..(SCRIPTNAME or "<this script>").." <options> <pattern> <filename>*\n"
-usage_message = usage_message .. "Valid <options> are: " .. table.concat(valid_options, " ")
-
-----------------------------------------------------------------------------------------
--- Option processing
-----------------------------------------------------------------------------------------
-
-function invalid_option(j)
-   greeting()
-   io.write("Rosie: invalid command line option ", arg[j], "\n")
-   if arg[j]=="-" then
-      io.write("\tHint: A single dash can replace the manifest filename to prevent a manifest from loading, or\n")
-      io.write("\tit can be the last (or only) input file name, which causes input to be read from the stdin.\n")
-   end
-   io.write(usage_message, "\n")
-   os.exit(-1)
-end
-
-function process_command_line_options()
-   OPTION = {}				    -- GLOBAL array indexed by option name
-   local last_option = 0		    -- index of last command line option found
-   local value
-   local i=1
-   while arg[i] do
-      local v = arg[i]
-      if valid_option_is(v) then
-	 if option_takes_arg(v) then
-	    value = arg[i+1]
-	    last_option = i+1;
-	 else
-	    value = true
-	    last_option = i;
-	 end
-	 OPTION[v] = value
-      else
-	 break;
-      end
-      i = last_option+1;
-   end -- while
-
-   -- i is now the first non-option argument, which should be a pattern expression
-   if arg[i] then
-      if arg[i]:sub(1,1)=="-" then invalid_option(i); end
-      opt_pattern = arg[i]
-      i = i+1
-   end
-
-   -- any remaining args are filenames, only the last of which can be "-"
-   local firstfile = i
-   while arg[i] do
-      local v = arg[i]
-      if (v=="-") and (arg[i+1]) then invalid_option(i); end
-      i = i+1
-   end
-
-   if firstfile==i then
-      -- no files on command line
-      opt_filenames = nil
-   else
-      opt_filenames = {table.unpack(arg, firstfile)}
-   end
-
-   opt_manifest = OPTION["-manifest"] or "$sys/MANIFEST"
-   if opt_manifest==true then
-      io.write("Rosie: the manifest command line option requires a filename or - \n")
-      io.write(usage_message, "\n")
-      os.exit(-1)
-   elseif opt_manifest=="-" then
-      opt_manifest=nil
-   end
-
+	io.stderr:write("This is Rosie v" .. ROSIE_VERSION .. "\n")
 end
 
 function print_rosie_info()
+	-- Find the value of the environment variable "ROSIE_HOME", if it is defined
+	if not ((type(os)=="table") and (type(os.getenv)=="function")) then
+		error("Internal error: os functions unavailable; cannot use getenv to find ROSIE_HOME")
+	end
+	local ok, env_ROSIE_HOME = pcall(os.getenv, "ROSIE_HOME")
+	if not ok then
+		error("Internal error: call to os.getenv failed")
+	end
 
-   -- Find the value of the environment variable "ROSIE_HOME", if it is defined
-   if not ((type(os)=="table") and (type(os.getenv)=="function")) then
-      error("Internal error: os functions unavailable; cannot use getenv to find ROSIE_HOME")
-   end
-   local ok, env_ROSIE_HOME = pcall(os.getenv, "ROSIE_HOME")
-   if not ok then
-      error("Internal error: call to os.getenv failed")
-   end
-
-   local rosie_home_message = ((SCRIPT_ROSIE_HOME and " (from environment variable $ROSIE_HOME)") or
-			       " (provided by the program that initialized Rosie)")
-   print("Local installation information:")
-   print("  ROSIE_HOME = " .. ROSIE_HOME)
-   print("  ROSIE_VERSION = " .. ROSIE_VERSION)
-   print("  HOSTNAME = " .. (os.getenv("HOSTNAME") or ""))
-   print("  HOSTTYPE = " .. (os.getenv("HOSTTYPE") or ""))
-   print("  OSTYPE = " .. (os.getenv("OSTYPE") or ""))
-   print("Current invocation: ")
-   print("  current working directory = " .. (os.getenv("CWD") or ""))
-   print("  invocation command = " .. (SCRIPTNAME or ""))
-   print("  script value of Rosie home = " .. (os.getenv("ROSIE_SCRIPT_HOME") or "(not set???)"))
-   local env_var_msg = "  environment variable $ROSIE_HOME "
-   if env_ROSIE_HOME then
-      if env_ROSIE_HOME=="" then
-	 env_var_msg = env_var_msg .. "is set to the empty string"
-      else
-	 env_var_msg = env_var_msg .. "= " .. tostring(env_ROSIE_HOME)
-      end
-   else
-      env_var_msg = env_var_msg .. "is not set"
-   end
-   print(env_var_msg)
+	local rosie_home_message = ((SCRIPT_ROSIE_HOME and " (from environment variable $ROSIE_HOME)") or
+			" (provided by the program that initialized Rosie)")
+	print("Local installation information:")
+	print("  ROSIE_HOME = " .. ROSIE_HOME)
+	print("  ROSIE_VERSION = " .. ROSIE_VERSION)
+	print("  HOSTNAME = " .. (os.getenv("HOSTNAME") or ""))
+	print("  HOSTTYPE = " .. (os.getenv("HOSTTYPE") or ""))
+	print("  OSTYPE = " .. (os.getenv("OSTYPE") or ""))
+	print("Current invocation: ")
+	print("  current working directory = " .. (os.getenv("CWD") or ""))
+	print("  invocation command = " .. (SCRIPTNAME or ""))
+	print("  script value of Rosie home = " .. (os.getenv("ROSIE_SCRIPT_HOME") or "(not set???)"))
+	local env_var_msg = "  environment variable $ROSIE_HOME "
+	if env_ROSIE_HOME then
+		if env_ROSIE_HOME=="" then
+			env_var_msg = env_var_msg .. "is set to the empty string"
+		else
+			env_var_msg = env_var_msg .. "= " .. tostring(env_ROSIE_HOME)
+		end
+	else
+		env_var_msg = env_var_msg .. "is not set"
+	end
+	print(env_var_msg)
 end
 
-function help()
-   greeting()
-   print("Help:")
-   print(usage_message)
-   print()
-   local line
-   for _, cmd in ipairs(valid_options) do
-      if member(cmd, options_without_args) then
-	 line = string.format("%-18s %s", cmd, help_messages[cmd][1])
-      else
-	 line = string.format("%-18s %s", cmd .. " <arg>", help_messages[cmd][1])
-      end
-      print(line)
-      for i=2,#help_messages[cmd] do
-	 print("                   " .. help_messages[cmd][i])
-      end
-   end -- for each cmd
-   print()
-   print("<pattern>            RPL expression, which may be the name of a defined pattern,")
-   print("                     against which each line will be matched")
-   print("<filename>+          one or more file names to process, the last of which may be")
-   print("                     a dash \"-\" to read from standard input")
-   print()
-   print("Notes: ")
-   print("(1) lines from the input file for which the pattern does NOT match are written")
-   print("    to stderr so they can be redirected, e.g. to /dev/null")
-   print("(2) the -eval option currently does not work with the -grep option")
-   print()
+function setup_engine(args)
+	-- (1a) Load the manifest
+	if args.manifest then
+		if args.verbose then
+			io.stdout:write("Compiling files listed in manifest ", args.manifest, "\n")
+		end
+		local success, messages = lapi.load_manifest(CL_ENGINE, args.manifest)
+		if not success then
+			for _,msg in ipairs(messages) do
+				if msg then
+					io.stdout:write(msg, "\n")
+				end
+			end
+			os.exit(-4)
+		end
+	end
+
+	-- (1b) Load an rpl file
+	if args.rpls then
+		for _,file in pairs(args.rpls) do
+			if args.verbose then
+				io.stdout:write("Compiling additional file ", file, "\n")
+			end
+			local success, msg = lapi.load_file(CL_ENGINE, file)
+			if not success then
+				io.stdout:write(msg, "\n")
+				os.exit(-4)
+			end
+		end
+	end
+
+	-- (1c) Load an rpl string from the command line
+	if args.statements then
+		for _,stm in pairs(args.statements) do
+			if args.verbose then
+				io.stdout:write(string.format("Compiling additional rpl code %q\n", stm))
+			end
+			local success, msg = lapi.load_string(CL_ENGINE, stm)
+			if not success then
+				io.stdout:write(msg, "\n")
+				os.exit(-4)
+			end
+		end
+	end
+
+	-- (2) Compile the expression
+	if args.pattern then
+		local success, msg
+		if args.grep then
+			success, msg = lapi.set_match_exp_grep_TEMPORARY(CL_ENGINE, args.pattern, "json")
+		else
+			success, msg = lapi.configure_engine(CL_ENGINE, {expression=args.pattern, encode="json"})
+		end
+		if not success then
+			io.write(msg, "\n")
+			os.exit(-1);
+		end
+	end
 end
 
-function setup_engine()
-   if OPTION["-grep"] and OPTION["-eval"] then
-      print("Error: currently, the -grep option and the -eval option are incompatible.  Use one or the other.")
-      os.exit(-1)
-   end
-   local eval = OPTION["-eval"]
+function process_pattern_against_file(args, infilename)
+	-- (3) Set up the input, output and error parameters
+	if infilename=="-" then infilename = ""; end	    -- stdin
+	outfilename = ""				    -- stdout
+	errfilename = "/dev/null"
+	if args.all then errfilename = ""; end			-- stderr
 
-   -- (1a) Load the manifest
-   if opt_manifest then
-      if not QUIET then io.stdout:write("Compiling files listed in manifest ", opt_manifest, "\n"); end
-      local success, messages = lapi.load_manifest(CL_ENGINE, opt_manifest)
-      if not success then
-	 for _,msg in ipairs(messages) do if msg then io.stdout:write(msg, "\n"); end; end
-	 os.exit(-4)
-      end
-   end
+	-- (4) Set up what kind of encoding we want done on the output
+	encode = args.encode -- default is color
+	success, msg = lapi.configure_engine(CL_ENGINE, {encode=encode})
+	if not success then io.write("Engine configuration error: ", msg, "\n"); os.exit(-1); end
 
-   -- (1b) Load an rpl file
-   if OPTION["-f"] then
-      if not QUIET then io.stdout:write("Compiling additional file ", OPTION["-f"], "\n"); end
-      local success, msg = lapi.load_file(CL_ENGINE, OPTION["-f"])
-      if not success then
-	 io.stdout:write(msg, "\n")
-	 os.exit(-4)
-      end
-   end
+	-- (5) Iterate through the lines in the input file
+	local match_function = lapi.match_file
+	if eval then match_function = lapi.eval_file; end
+	local cin, cout, cerr = match_function(CL_ENGINE, infilename, outfilename, errfilename, args.wholefile)--OPTION["-wholefile"])
+	if not cin then io.write(cout, "\n"); os.exit(-1); end -- cout is error message in this case
 
-   -- (1c) Load an rpl string from the command line
-   if OPTION["-e"] then
-      if not QUIET then io.stdout:write(string.format("Compiling additional rpl code %q\n",  OPTION["-e"])); end
-      local success, msg = lapi.load_string(CL_ENGINE, OPTION["-e"])
-      if not success then
-	 io.stdout:write(msg, "\n")
-	 os.exit(-4)
-      end
-   end
-
-   -- (2) Compile the expression
-   if opt_pattern then
-      local success, msg
-      if OPTION["-grep"] then
-	 success, msg = lapi.set_match_exp_grep_TEMPORARY(CL_ENGINE, opt_pattern, "json")
-      else
-	 success, msg = lapi.configure_engine(CL_ENGINE, {expression=opt_pattern, encode="json"})
-      end
-      if not success then io.write(msg, "\n"); os.exit(-1); end
-   end
+	-- (6) Print summary
+	if args.verbose then
+		local fmt = "Rosie: %d input items processed (%d matches, %d items unmatched)\n"
+		io.stderr:write(string.format(fmt, cin, cout, cerr))
+	end
 end
 
-function process_pattern_against_file(infilename)
-   -- (3) Set up the input, output and error parameters
-   if infilename=="-" then infilename = ""; end	    -- stdin
-   outfilename = ""				    -- stdout
-   errfilename = "/dev/null"
-   if OPTION["-all"] then errfilename = ""; end	    -- stderr
+function run(args)
+	if args.command == "info" then
+		print_rosie_info()
+		os.exit()
+	end
 
-   -- (4) Set up what kind of encoding we want done on the output
-   encode = OPTION["-encode"] or "color"
-   success, msg = lapi.configure_engine(CL_ENGINE, {encode=encode})
-   if not success then io.write("Engine configuration error: ", msg, "\n"); os.exit(-1); end
+	if args.verbose then greeting(); end
 
-   -- (5) Iterate through the lines in the input file
-   local match_function = lapi.match_file
-   if eval then match_function = lapi.eval_file; end
-   local cin, cout, cerr = match_function(CL_ENGINE, infilename, outfilename, errfilename, OPTION["-wholefile"])
-   if not cin then io.write(cout, "\n"); os.exit(-1); end -- cout is error message in this case
+	setup_engine(args);
 
-   -- (6) Print summary
-   if not QUIET then
-      local fmt = "Rosie: %d input items processed (%d matches, %d items unmatched)\n"
-      io.stderr:write(string.format(fmt, cin, cout, cerr))
-   end
-end
+	if args.command == "patterns" then
+		if not args.verbose then greeting(); end
+		local env = lapi.get_environment(CL_ENGINE)
+		common.print_env(env)
+		os.exit()
+	end
 
-function run()
-   process_command_line_options()
+	if args.command == "repl" then
+		if not args.verbose then greeting(); end
+		repl(CL_ENGINE)
+		os.exit()
+	end
 
-   if OPTION["-verbose"] then
-      QUIET = false;
-   else
-      QUIET = true;
-   end
-
-   if OPTION["-help"] then
-      if #arg > 1 then print("Rosie CLI warning: ignoring extraneous command line arguments"); end
-      help()
-      os.exit()
-   end
-
-   if OPTION["-info"] then
-      if #arg > 1 then print("Rosie CLI warning: ignoring extraneous command line arguments"); end
-      print_rosie_info()
-      os.exit()
-   end
-
-   if not QUIET then greeting(); end
-
-   setup_engine();
-
-   if OPTION["-patterns"] then
-      if QUIET then greeting(); end
-      local env = lapi.get_environment(CL_ENGINE)
-      common.print_env(env)
-      os.exit()
-   end
-
-   if OPTION["-repl"] then
-      if QUIET then greeting(); end
-      repl(CL_ENGINE)
-   else
-      if not opt_pattern then print("Rosie CLI warning: missing pattern argument"); end
-
-      if opt_filenames then
-	 for _,fn in ipairs(opt_filenames) do
-	    if (not QUIET) or (#opt_filenames>1) then print("\n" .. fn .. ":"); end
-	    process_pattern_against_file(fn)
-	 end -- for each file
-      else
-	 print("Rosie CLI warning: missing filename arguments")
-      end
-   end
+	for _,fn in ipairs(args.filename) do
+		if (args.verbose) or (#args.filename > 1) then
+			print("\n" .. fn .. ":")
+		end
+		process_pattern_against_file(args, fn)
+	end
 end -- function run
 
 ----------------------------------------------------------------------------------------
 -- Do stuff
 ----------------------------------------------------------------------------------------
 
-if (not arg[1]) then
-   -- no command line options were supplied
-   greeting()
-   print(usage_message)
-else
-   run()
-end
+-- create Parser
+local parser = argparse("rosie", "Rosie Pattern Language")
+	:epilog("Additional information.")
+-- global flags/options can go here
+-- -h,--help is generated automatically
+-- usage message is generated automatically
+parser:flag("-v --verbose", "Output additional messages")
+	:default(false)
+	:action("store_true")
+parser:option("-m --manifest", "Load a manifest file")
+	:default("$sys/MANIFEST")
+	:args(1)
+parser:option("-f --load", "Load an RPL file")
+	:args(1)
+	:count("*") -- allow multiple loads of a file
+	:target("rpls") -- set name of variable index (args.rpls)
+parser:option("-r --rpl", "Inline RPL statements")
+	:args(1)
+	:count("*") -- allow multiple RPL statements
+	:target("statements") -- set name of variable index (args.statements)
+--parser:flag("--asdf", "description")
+--parser:option("--lkj", "description"):args(1)
+-- target variable for commands
+parser:command_target("command")
+-- info command
+local info = parser:command("info")
+	:description("Print rosie installation information")
+-- patterns command
+local patterns = parser:command("patterns")
+	:description("List installed patterns")
+-- repl command
+local repl = parser:command("repl")
+	:description("Run rosie in interactive mode")
+-- match command
+local match = parser:command("match")
+	:description("Run RPL match")
+-- match flags (true/false)
+match:flag("-s --wholefile", "Read input file as single string")
+	:default(false)
+	:action("store_true")
+match:flag("-a --all", "Output non-matching lines to stderr")
+	:default(false)
+	:action("store_true")
+-- mutually exclusive flags
+match:mutex(
+	match:flag("-e --eval", "Output detailed trace evaluation of pattern process.")
+		:default(false)
+		:action("store_true"),
+	match:flag("-g --grep", "Weakly emulate grep using RPL syntax")
+		:default(false)
+		:action("store_true")
+)
+-- match options (takes an argument)
+match:option("-o --encode", "Output format")
+	:convert(function(a)
+		-- validation of argument, will fail if not in choices array
+		choices={"color","nocolor","fulltext","json"}
+		for j=1,#choices do
+			if a == choices[j] then
+				return a
+			end
+		end
+		return nil
+		end)
+	:default("color")
+	:args(1) -- consume argument after option
+-- match arguments (required options)
+match:argument("pattern", "RPL pattern")
+match:argument("filename", "Input filename")
+	:args("*")
+	:default("-") -- in case no filenames are passed, default to stdin
+-- parse command-line
+local args = parser:parse()
+run(args)

--- a/src/run.lua
+++ b/src/run.lua
@@ -288,6 +288,11 @@ match:argument("pattern", "RPL pattern")
 match:argument("filename", "Input filename")
 	:args("*")
 	:default("-") -- in case no filenames are passed, default to stdin
--- parse command-line
-local args = parser:parse()
-run(args)
+-- in order to catch dev mode for "make test"
+if (not arg[1]) then
+	print(parser:get_help())
+else
+	-- parse command-line
+	local args = parser:parse()
+	run(args)
+end

--- a/src/run.lua
+++ b/src/run.lua
@@ -213,11 +213,16 @@ end -- function run
 ----------------------------------------------------------------------------------------
 
 -- create Parser
-local parser = argparse("rosie", "Rosie Pattern Language")
+local parser = argparse("rosie", "Rosie Pattern Language v" .. ROSIE_VERSION)
 	:epilog("Additional information.")
 -- global flags/options can go here
 -- -h,--help is generated automatically
 -- usage message is generated automatically
+parser:flag("--version", "Print rosie version")
+	:action(function(args,_,exceptions)
+		greeting()
+		os.exit()
+	end)
 parser:flag("-v --verbose", "Output additional messages")
 	:default(false)
 	:action("store_true")

--- a/test/cli-test.lua
+++ b/test/cli-test.lua
@@ -41,8 +41,8 @@ function run(expression, grep_flag, expectations)
    test.subheading((grep_flag and "Using grep option") or "No grep option")
    local verb = (grep_flag and "Grepping for") or "Matching"
    print("\nSTART ----------------- " .. verb .. " '" .. expression .. "' against fixed input -----------------")
-   local grep = (grep_flag and " -grep") or ""
-   local cmd = rosie .. grep .. " '" .. expression .. "' " .. infilename
+   local grep = (grep_flag and " --grep") or ""
+   local cmd = rosie .. " match".. grep .. " '" .. expression .. "' " .. infilename
    print(cmd)
    local results, status, code = util.os_execute_capture(cmd, nil, "l")
    if not results then error("Run failed: " .. tostring(status) .. ", " .. tostring(code)); end


### PR DESCRIPTION
This expands on the argparse PR #13 to add a test command for #34 

Tests are added inside RPL files as a comment, matched based upon this rosie expression:
```
testKeyword = "accepts" / "rejects"
test_line = "-- test" identifier testKeyword quoted_string (ignore "," ignore quoted_string)*
```

Sample test lines:
```
-- test common.int accepts "34", "+34", "-34
-- test common.int rejects "BEEF", "0x20"
```
Multiple lines testing the same identifier are allowed, so the above accepts line can also be written as:
```
-- test common.int accepts "34"
-- test common.int accepts "+34"
-- test common.int accepts "-34"
```

When run, a failure will produce output for each failed string. For instance adding "123" to the `common.int` rejects line will produce this output:
```
$ bin/rosie test rpl/common.rpl 
FAIL: common.int did not reject 123
```

A successful test run will produce this output:
```
$ bin/rosie test rpl/common.rpl 
All tests passed
```

If no test lines are found:
```
$ bin/rosie test rpl/basic.rpl 
No tests found
```