### PR TITLE
make readlinetest Linux fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ CJSON_MAKE_ARGS += CJSON_LDFLAGS+=-pthread
 # Sigh.  Once we get to Version 1.0 and we support Linux packages (like RPM), we won't need this test.
 # Note that this test should ALWAYS pass on OS X, since it ships with readline.
 readlinetest:
-	@(bash -c 'printf "#include <readline/readline.h>\nint main() { }\n"' | \
+	@(bash -c 'printf "#include <stdio.h>\n#include <readline/readline.h>\nint main() { }\n"' | \
 	           cc -std=gnu99 -lreadline -o /dev/null -xc -) && \
 	   echo "READLINE TEST: libreadline and readline.h appear to be installed" || \
 	   (echo "READLINE TEST: Missing readline library or readline.h" && \


### PR DESCRIPTION
Unsure if this works as-is on your Mac @jamiejennings, but on Linux I needed to add `#include <stdio.h>\n` to the readlinetest Makefile rule.

Error:
```
$ make readlinetest
In file included from /usr/include/readline/readline.h:35:0,
                 from <stdin>:1:
/usr/include/readline/rltypedefs.h:71:28: error: unknown type name ‘FILE’
 typedef int rl_getc_func_t PARAMS((FILE *));
                            ^
/usr/include/readline/readline.h:423:20: error: unknown type name ‘FILE’
 extern int rl_getc PARAMS((FILE *));
                    ^
In file included from <stdin>:1:0:
/usr/include/readline/readline.h:550:8: error: unknown type name ‘FILE’
 extern FILE *rl_instream;
        ^~~~
/usr/include/readline/readline.h:551:8: error: unknown type name ‘FILE’
 extern FILE *rl_outstream;
        ^~~~
/usr/include/readline/readline.h:580:8: error: unknown type name ‘rl_getc_func_t’
 extern rl_getc_func_t *rl_getc_function;
        ^~~~~~~~~~~~~~
/usr/include/readline/readline.h:899:3: error: unknown type name ‘FILE’
   FILE *inf;
   ^~~~
/usr/include/readline/readline.h:900:3: error: unknown type name ‘FILE’
   FILE *outf;
   ^~~~
READLINE TEST: Missing readline library or readline.h
READLINE TEST: See https://github.com/jamiejennings/rosie-pattern-language#how-to-build-clone-the-repo-and-type-make
Makefile:86: recipe for target 'readlinetest' failed
make: *** [readlinetest] Error 1
```