### PR TITLE
Fix .patterns to allow numeric search filter

### DIFF
--- a/src/core/repl.lua
+++ b/src/core/repl.lua
@@ -26,7 +26,8 @@ local repl_patterns = [==[
       eval = ".eval" args
       on_off = "on" / "off"
       debug = ".debug" on_off?
-      patterns = ".patterns" identifier?
+      alnum = { [[:alpha:]] / [[:digit:]] }
+      patterns = ".patterns" { identifier / {alnum+} }?
       star = "*"
       clear = ".clear" (identifier / star)?
       help = ".help"


### PR DESCRIPTION
Allows for filtering on a number, and possibly followed by characters.