### PR TITLE
Update librosie Makefile and Dockerfiles

### DIFF
--- a/docker/Dockerfile.arch
+++ b/docker/Dockerfile.arch
@@ -5,8 +5,8 @@ RUN pacman -S --noconfirm gcc
 RUN pacman -S --noconfirm readline
 
 # Option 1: Install git and clone the repository.  Works if the container has internet access.
-#RUN apt-get install --yes git
-#RUN git clone --recursive https://github.com/jamiejennings/rosie-pattern-language.git /opt/
+#RUN pacman -S --noconfirm  git
+#RUN git clone --recursive https://github.com/jamiejennings/rosie-pattern-language.git /opt/rosie
 
 # Option 2: Copy the files from the local directory
 ADD . /opt/rosie/

--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -7,8 +7,8 @@ RUN dnf install -y readline-devel
 RUN dnf install -y procps
 
 # Option 1: Install git and clone the repository.  Works if the container has internet access.
-#RUN dnf install git
-#git clone https://github.com/jamiejennings/rosie-pattern-language.git /opt/
+#RUN dnf install -y git
+#RUN git clone https://github.com/jamiejennings/rosie-pattern-language.git /opt/rosie
 
 # Option 2: Copy the files from the local directory
 ADD . /opt/rosie/

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -8,7 +8,7 @@ RUN apt-get install --yes libreadline6-dev
 
 # Option 1: Install git and clone the repository.  Works if the container has internet access.
 #RUN apt-get install --yes git
-#RUN git clone --recursive https://github.com/jamiejennings/rosie-pattern-language.git /opt/
+#RUN git clone --recursive https://github.com/jamiejennings/rosie-pattern-language.git /opt/rosie
 
 # Option 2: Copy the files from the local directory
 ADD . /opt/rosie/

--- a/ffi/librosie/Makefile
+++ b/ffi/librosie/Makefile
@@ -106,7 +106,7 @@ none:
 	@echo "Your platform was not recognized.  Please do 'make PLATFORM', where PLATFORM is one of these: $(PLATFORMS)"
 
 linux:
-	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX -D_GNU_SOURCE=1 -fPIC" SYSLIBS="-Wl,-E -ldl -lreadline"
+	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX -std=gnu99 -D_GNU_SOURCE=1 -fPIC" SYSLIBS="-Wl,-E -ldl -lreadline"
 
 macosx:
 	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX" SYSLIBS= CC=$(CC)


### PR DESCRIPTION
Ran into issues building librosie on Debian, updated makefile to add `-std=GNU99`. Just picked the one that MacOSX was using. Also updated Dockerfiles so  the git option worked. If you want to see the error output debian gave me, here's the [gist](https://gist.github.com/Subzidion/6d5686ff52b84ee91f4b92b94c507d59).